### PR TITLE
Updates for plugin

### DIFF
--- a/cartridges/plugin_gtm/cartridge/scripts/hooks/gtm/gtmhooks.js
+++ b/cartridges/plugin_gtm/cartridge/scripts/hooks/gtm/gtmhooks.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Site = require('dw/system/Site');
 var velocity = require('dw/template/Velocity');
 var gtmHelpers = require('*/cartridge/scripts/gtm/gtmHelpers');
 
@@ -15,7 +14,7 @@ function htmlHead(pdict) {
     {
         velocity: velocity,
         action: pdict.action,
-        datalayer: JSON.stringify(datalayer)
+        datalayer: JSON.stringify(datalayer) || ''
     });
 }
 

--- a/cartridges/plugin_gtm/cartridge/templates/default/common/layout/checkout.isml
+++ b/cartridges/plugin_gtm/cartridge/templates/default/common/layout/checkout.isml
@@ -3,7 +3,7 @@
 <isinclude template="/components/modules" sf-toolkit="off" />
 
 <!DOCTYPE html>
-<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage()}">
+<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage() || 'en'}">
     <head>
         <!--[if gt IE 9]><!-->
             <isinclude sf-toolkit="off" template="/common/scripts" />

--- a/cartridges/plugin_gtm/cartridge/templates/default/common/layout/page.isml
+++ b/cartridges/plugin_gtm/cartridge/templates/default/common/layout/page.isml
@@ -3,7 +3,7 @@
 <isinclude template="/components/modules" sf-toolkit="off" />
 
 <!DOCTYPE html>
-<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage()}">
+<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage() || 'en'}">
     <head>
         <!--[if gt IE 9]><!-->
             <isinclude sf-toolkit="off" template="/common/scripts" />

--- a/cartridges/plugin_gtm/cartridge/templates/default/common/layout/pdStorePage.isml
+++ b/cartridges/plugin_gtm/cartridge/templates/default/common/layout/pdStorePage.isml
@@ -16,7 +16,7 @@
 </isscript>
 
 <!DOCTYPE html>
-<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage()}">
+<html lang="${require('dw/util/Locale').getLocale(request.getLocale()).getLanguage() || 'en'}">
     <head>
         <!--[if gt IE 9]><!-->
             <isinclude sf-toolkit="off" template="/common/scripts" />


### PR DESCRIPTION
gtmHelpers.js 
- add additional cases for homepage that were found to be rendering in various test cases
- additional order retrieval cases with default case in instances were order retrieval fails

gtmhooks.js 
- default dataLayer value to empty string if it is null to alleviate null error found in logs

templates
- add default locale value to lang attribute